### PR TITLE
Update 001_create_orm_resources.rb

### DIFF
--- a/db/migrations/001_create_orm_resources.rb
+++ b/db/migrations/001_create_orm_resources.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 Sequel.migration do
   change do
-    run 'CREATE EXTENSION "uuid-ossp"'
+    run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
     create_table :orm_resources do
       column :id, :uuid, default: Sequel.function(:uuid_generate_v4), primary_key: true
       column :metadata, :jsonb, default: '{}', index: { type: :gin }


### PR DESCRIPTION
Add "IF NOT EXISTS" in the migration for uuid-ossp extension. This way the script will still work if the extension is already enabled.