### PR TITLE
Lazy-load resources in .find_all

### DIFF
--- a/lib/valkyrie/sequel/query_service.rb
+++ b/lib/valkyrie/sequel/query_service.rb
@@ -9,7 +9,7 @@ module Valkyrie::Sequel
     end
 
     def find_all
-      resources.all.map do |attributes|
+      resources.stream.lazy.map do |attributes|
         resource_factory.to_resource(object: attributes)
       end
     end


### PR DESCRIPTION
This makes it so that for things like reindexing you can run
`each_slice` and it won't load the entire repository into memory first.