### PR TITLE
Use cursors for all over streams.

### DIFF
--- a/lib/valkyrie/sequel/query_service.rb
+++ b/lib/valkyrie/sequel/query_service.rb
@@ -9,7 +9,7 @@ module Valkyrie::Sequel
     end
 
     def find_all
-      resources.stream.lazy.map do |attributes|
+      resources.use_cursor.lazy.map do |attributes|
         resource_factory.to_resource(object: attributes)
       end
     end


### PR DESCRIPTION
A stream gets interrupted when you save to another persister, oddly
enough. Cursors continue to be able to be used.