### PR TITLE
Optimistic locking can be enabled at any time.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Metrics/ClassLength:
 Metrics/ParameterLists:
   Exclude:
     - 'lib/valkyrie/sequel/metadata_adapter.rb'
+RSpec/ExampleLength:
+  Exclude:
+    - 'spec/valkyrie/sequel/persister_spec.rb'

--- a/lib/valkyrie/sequel/resource_factory/orm_converter.rb
+++ b/lib/valkyrie/sequel/resource_factory/orm_converter.rb
@@ -27,6 +27,7 @@ module Valkyrie::Sequel
       # Construct the optimistic lock token using the adapter and lock version for the Resource
       # @return [Valkyrie::Persistence::OptimisticLockToken]
       def lock_token
+        return nil unless object[:lock_version].present?
         @lock_token ||=
           Valkyrie::Persistence::OptimisticLockToken.new(
             adapter_id: resource_factory.adapter_id,

--- a/lib/valkyrie/sequel/resource_factory/resource_converter.rb
+++ b/lib/valkyrie/sequel/resource_factory/resource_converter.rb
@@ -25,7 +25,7 @@ module Valkyrie::Sequel
       # @param [ORM::Resource] orm_object
       def process_lock_token(orm_object)
         return unless resource.respond_to?(Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK)
-        postgres_token = resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].find do |token|
+        postgres_token = (resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK] || []).find do |token|
           token.adapter_id == resource_factory.adapter_id
         end
         return unless postgres_token

--- a/spec/valkyrie/sequel/persister_spec.rb
+++ b/spec/valkyrie/sequel/persister_spec.rb
@@ -34,6 +34,62 @@ RSpec.describe Valkyrie::Sequel::Persister do
     end
   end
 
+  describe "save with optimistic locking being turned on later" do
+    it "doesn't break" do
+      class OptimisticResource < Valkyrie::Resource
+      end
+      resource = OptimisticResource.new
+      object = persister.save(resource: resource)
+      class OptimisticResource < Valkyrie::Resource
+        enable_optimistic_locking
+      end
+      result = query_service.find_by(id: object.id)
+      expect { persister.save(resource: result) }.not_to raise_error
+      result = query_service.find_by(id: object.id)
+      expect(result.optimistic_lock_token[0].token).to eq "1"
+    end
+    it "doesn't break with save_all" do
+      class OptimisticResource < Valkyrie::Resource
+      end
+      resource = OptimisticResource.new
+      objects = persister.save_all(resources: [resource])
+      class OptimisticResource < Valkyrie::Resource
+        enable_optimistic_locking
+      end
+      result = query_service.find_by(id: objects.first.id)
+      expect { persister.save_all(resources: [result]) }.not_to raise_error
+      result = query_service.find_by(id: objects.first.id)
+      expect(result.optimistic_lock_token[0].token).to eq "1"
+    end
+    it "doesn't break on a race condition" do
+      class OptimisticResource < Valkyrie::Resource
+      end
+      resource = OptimisticResource.new
+      resource = persister.save(resource: resource)
+      class OptimisticResource < Valkyrie::Resource
+        enable_optimistic_locking
+      end
+
+      persister.save(resource: resource)
+      expect { persister.save(resource: resource) }.to raise_error Valkyrie::Persistence::StaleObjectError
+    end
+    it "doesn't break on a race condition via save_all" do
+      class OptimisticResource < Valkyrie::Resource
+      end
+      resource = OptimisticResource.new
+      resource = persister.save(resource: resource)
+      class OptimisticResource < Valkyrie::Resource
+        enable_optimistic_locking
+      end
+
+      persister.save_all(resources: [resource])
+      expect { persister.save_all(resources: [resource]) }.to raise_error Valkyrie::Persistence::StaleObjectError
+    end
+    after do
+      Object.send(:remove_const, :OptimisticResource)
+    end
+  end
+
   describe "save_all with optimistic locking" do
     before do
       class OptimisticResource < Valkyrie::Resource


### PR DESCRIPTION
Allows for optimistic locking to be enabled in a production application even after some resources were created. Effectively treats a nil token as "0".