### PR TITLE
Release Valkyrie-Sequel 1.1

### DIFF
--- a/lib/valkyrie/sequel/version.rb
+++ b/lib/valkyrie/sequel/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Valkyrie
   module Sequel
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
Allows for Valkyrie 2.x and allows for optimistic locking to be enabled
post-production.