### PR TITLE
don't force UUID usage on queries client side; use psql instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/ruby:2.4.6-node-browsers
         environment:
           RAILS_ENV: test
+          BUNDLE_PATH: vendor/bundle
           DB_HOST: localhost
           DB_USERNAME: valkyrie_sequel
           DB_PASSWORD:  ""
@@ -23,7 +24,7 @@ jobs:
         key: valkyrie-sequel-{{ checksum "Gemfile" }}
       - run: gem install bundler -v '~> 2.0'
       # Bundle install dependencies
-      - run: bundle install --path vendor/bundle
+      - run: bundle install
       # Cache Dependencies
       - type: cache-save
         name: Store bundle cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.4.6-node-browsers
+      - image: circleci/ruby:2.7.2-node-browsers
         environment:
           RAILS_ENV: test
           BUNDLE_PATH: vendor/bundle

--- a/lib/valkyrie/sequel/query_service.rb
+++ b/lib/valkyrie/sequel/query_service.rb
@@ -49,7 +49,7 @@ module Valkyrie::Sequel
         id.to_s
       end
 
-      resources.where(id: ids).map do |attributes|
+      resources.where(Sequel.lit('(id::varchar) IN ?', ids)).map do |attributes|
         resource_factory.to_resource(object: attributes)
       end
     end

--- a/lib/valkyrie/sequel/query_service.rb
+++ b/lib/valkyrie/sequel/query_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Valkyrie::Sequel
   class QueryService
+    # ACCEPTABLE_UUID is deprecated and unused.
+    # which IDs are acceptable is now decided by the database.
     ACCEPTABLE_UUID = %r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}.freeze
     DEFAULT_ID_TYPE = :uuid
 

--- a/lib/valkyrie/sequel/query_service.rb
+++ b/lib/valkyrie/sequel/query_service.rb
@@ -2,6 +2,8 @@
 module Valkyrie::Sequel
   class QueryService
     ACCEPTABLE_UUID = %r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}.freeze
+    DEFAULT_ID_TYPE = :uuid
+
     attr_reader :adapter
     delegate :resources, :resource_factory, :connection, to: :adapter
     def initialize(adapter:)
@@ -222,7 +224,7 @@ module Valkyrie::Sequel
     # @see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaCache.html#method-i-columns_hash
     # @return [Symbol]
     def id_type
-      @id_type ||= :uuid
+      @id_type ||= DEFAULT_ID_TYPE
     end
 
     # Determines whether or not an Object is a Valkyrie ID

--- a/lib/valkyrie/sequel/resource_factory/resource_converter.rb
+++ b/lib/valkyrie/sequel/resource_factory/resource_converter.rb
@@ -23,7 +23,6 @@ module Valkyrie::Sequel
     def convert!
       output = database_hash
       output[:id] = resource.id.to_s if resource.id
-      output.delete(:id) unless !output[:id] || QueryService::ACCEPTABLE_UUID.match?(output[:id].to_s)
       process_lock_token(output)
       output
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,13 +2,7 @@
 ENV['RACK_ENV'] = 'test'
 ENV['RAILS_ENV'] = 'test'
 require 'simplecov'
-require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
-)
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 SimpleCov.start do
   add_filter 'spec'
   add_filter 'vendor'

--- a/valkyrie-sequel.gemspec
+++ b/valkyrie-sequel.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "bixby"
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "database_cleaner"
+  spec.add_development_dependency "database_cleaner", "< 2"
   spec.add_development_dependency "simplecov"
 end

--- a/valkyrie-sequel.gemspec
+++ b/valkyrie-sequel.gemspec
@@ -30,6 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bixby"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "database_cleaner"
-  spec.add_development_dependency "coveralls"
   spec.add_development_dependency "simplecov"
 end

--- a/valkyrie-sequel.gemspec
+++ b/valkyrie-sequel.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sequel"
-  spec.add_dependency "sequel_pg"
+  spec.add_dependency "sequel", "~> 5.0"
+  spec.add_dependency "sequel_pg", "~> 1.0"
   spec.add_dependency "valkyrie", '~> 2.1.0'
-  spec.add_dependency "oj"
+  spec.add_dependency "oj", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
this guard prevents applications from querying valid existing ids--leading to `ObjectNotFound` errors when objects exist in the DB backend.