### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/lib/valkyrie/sequel/version.rb
+++ b/lib/valkyrie/sequel/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Valkyrie
   module Sequel
-    VERSION = "2.1.0"
+    VERSION = "2.2.0"
   end
 end


### PR DESCRIPTION
this release adds support for database schemas a non-UUID `id`
field. e.g. `column :id, :bigint, identity: true`.

identifier type filtering is removed from the client side, in favor of typed
queries (`Sequel.lit('(id::varchar) IN ?', ids)`).