### PR TITLE
restrict valkyrie support to < 2.3

### DIFF
--- a/valkyrie-sequel.gemspec
+++ b/valkyrie-sequel.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "sequel", "~> 5.0"
   spec.add_dependency "sequel_pg", "~> 1.0"
-  spec.add_dependency "valkyrie", '~> 2.1'
+  spec.add_dependency "valkyrie", ">= 2.1", "< 2.3"
   spec.add_dependency "oj", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
since new queries can be introduced in minor valkyrie versions, and query
adapters are required to support them to be compatible, we can't guarantee
compatibility for not-yet-relased valkyrie minor versions.

limit our dependency spec to current valkyire versions.